### PR TITLE
调用Signature.Sign(url)生成的管理凭证是无效的

### DIFF
--- a/Qiniu/RS/BucketManager.cs
+++ b/Qiniu/RS/BucketManager.cs
@@ -31,7 +31,7 @@ namespace Qiniu.RS
         /// <returns></returns>
         public string CreateManageToken(string url)
         {
-            return string.Format("QBox {0}", signature.Sign(url));
+            return CreateManageToken(url, null);
         }
 
         /// <summary>


### PR DESCRIPTION
调用Signature.Sign(url)生成的管理凭证是无效的，因为计算签名时用的是包含域名部分的绝对路径，而且没有在路径最后加\n， 换成Signature.SignRequest方法就可以生成有效的管理凭证了