### PR TITLE
新增：HttpManager.get对于WebException的处理

### DIFF
--- a/Qiniu/Http/HttpManager.cs
+++ b/Qiniu/Http/HttpManager.cs
@@ -55,6 +55,12 @@ namespace Qiniu.Http
             {
                 vWebReq = (HttpWebRequest)WebRequest.Create(pUrl);
             }
+            catch(WebException wexp)
+            {
+                // FIX-HTTP 4xx/5xx Error 2016-11-22, 17:00 @fengyh
+                HttpWebResponse xWebResp = wexp.Response as HttpWebResponse;
+                handleErrorWebResponse(xWebResp, pCompletionHandler, wexp);
+            }
             catch (Exception ex)
             {
                 if (pCompletionHandler != null)


### PR DESCRIPTION
BucketManager.stat等操作调用到HttpManager.get方法，如果出现错误(如502错误)能够及时被处理。