### PR TITLE
C# SDK 使用指南链接失效

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 使用
 
-* 参考文档：[七牛云存储 C# SDK 使用指南](https://developer.qiniu.com/kodo/sdk/4055/csharp-sdk)
+* 参考文档：[七牛云存储 C# SDK 使用指南](https://developer.qiniu.com/kodo/sdk/1237/csharp)
 * 可以参考我们为大家精心准备的使用 [实例](https://github.com/qiniu/csharp-sdk/tree/master/src/QiniuTests)
 
 


### PR DESCRIPTION
C# SDK 使用指南链接失效
（此次PR更新为有效的链接地址）