### PR TITLE
fix content-type error

### DIFF
--- a/src/Qiniu/Http/HttpManager.cs
+++ b/src/Qiniu/Http/HttpManager.cs
@@ -112,14 +112,15 @@ namespace Qiniu.Http
                 wReq.Method = "GET";
                 if (headers != null)
                 {
-                    foreach (string fieldName in headers.Keys)
-                    {
-                        wReq.Headers.Add(fieldName, headers[fieldName]);
-                    }
-
                     if (headers.ContainsKey("Content-Type"))
                     {
                         wReq.ContentType = headers["Content-Type"];
+                        headers.Remove("Content-Type");
+                    }
+
+                    foreach (string fieldName in headers.Keys)
+                    {
+                        wReq.Headers.Add(fieldName, headers[fieldName]);
                     }
                 }
                 if (!string.IsNullOrEmpty(token))
@@ -262,14 +263,15 @@ namespace Qiniu.Http
                 wReq.Method = "POST";
                 if (headers != null)
                 {
-                    foreach (string fieldName in headers.Keys)
-                    {
-                        wReq.Headers.Add(fieldName, headers[fieldName]);
-                    }
-
                     if (headers.ContainsKey("Content-Type"))
                     {
                         wReq.ContentType = headers["Content-Type"];
+                        headers.Remove("Content-Type");
+                    }
+
+                    foreach (string fieldName in headers.Keys)
+                    {
+                        wReq.Headers.Add(fieldName, headers[fieldName]);
                     }
                 }
                 if (!string.IsNullOrEmpty(token))


### PR DESCRIPTION
HttpManager类的Post和Get函数会引发异常。

### 异常信息：
```json
{
  code:0
  
  ref-code:0
  ref-text:
  [2022-10-18 11:23:33.4841] [QiniuCSharpSDK/8.2.0 (UNKNOWN; Win32NT; 6.2.9200.0)] [HTTP-POST] Error:  必须使用适当的属性或方法修改“content-type”标头。
  参数名: name 


}
```

经过排查，发现是

```c#
foreach (string fieldName in headers.Keys)
{
      wReq.Headers.Add(fieldName, headers[fieldName]);
}     
```

循环头部信息时，`Content-Type`也在其中
`Content-Type`不能在头部进行设置，只能通过`Content-Type`属性设置

### 系统环境：
* Windows 10 专业版 1903(18362.295)
* .Net Framework 4.7.2
* Visual Studio 2019 Community 16.11.18